### PR TITLE
Fix taskCompletionSourceVariable that gets 'nulled' when a task is co…

### DIFF
--- a/BlazorDialog/Components/Dialog.razor
+++ b/BlazorDialog/Components/Dialog.razor
@@ -166,7 +166,6 @@
             if (taskCompletionSource != null)
             {
                 taskCompletionSource.SetResult(result);
-                taskCompletionSource = null;
             }
         };
     }

--- a/TestApps/BlazorDialog.TestAppsCommon/IndexCommon.razor
+++ b/TestApps/BlazorDialog.TestAppsCommon/IndexCommon.razor
@@ -129,14 +129,15 @@
 <button @onclick="SimpleDialogOnClick">Simple Dialog</button>
 <button @onclick="SimpleDialogBigOnClick">Simple Dialog Big</button>
 <button @onclick="SimpleLargeDialogDisablePreventNavigation">Simple Dialog Big allow navigation</button>
-
+<button @onclick="SimpleDialogBackToBack">Simple Dialog BackToBack</button>
 @if (dialogResult != null)
 {
-    <div>DialogResult: @dialogResult</div>
+    <div>DialogResult: @dialogResult  @((secondDialogResult != null) ? "and " + secondDialogResult : "") </div>
 }
 
-@code{
+@code {
     string dialogResult = null;
+    string secondDialogResult = null;
     bool isCentered;
     DialogSize size;
     DialogAnimation animation;
@@ -145,6 +146,16 @@
     async Task SimpleDialogOnClick()
     {
         dialogResult = await dialogService.ShowDialog<string>("simple-dialog", "(Simple Dialog) Are you sure?");
+    }
+
+    async Task SimpleDialogBackToBack()
+    {
+        dialogResult = await dialogService.ShowDialog<string>("simple-dialog", "(Simple Dialog) Are you sure?");
+        if (dialogResult == "no")
+        {
+            return;
+        }
+        secondDialogResult = await dialogService.ShowDialog<string>("simple-dialog", "(Simple Dialog) Are you really sure?");
     }
 
     async Task SimpleDialogBigOnClick()


### PR DESCRIPTION
**Issue Summary:**
An issue was identified in the dialog component, specifically when the same dialog is presented consecutively. The problem was that the task waiting for the result of the second dialog instance was being set to null, causing the response to never return.

**Root Cause:**
The root cause of the issue was the premature nullification of taskCompletionSource. When a task was completed, taskCompletionSource was set to null. If the dialog was shown again immediately, a new task was created, but the taskCompletionSource for this new task was also set to null, resulting in the loss of the task's result.

**Solution:**
To resolve this issue, the code that set taskCompletionSource to null upon task completion was removed. This change ensures that each new task is properly managed and retains its state until the dialog interaction completes. Additionally, the module is designed to handle past tasks by canceling them and relying on the garbage collector for disposal, ensuring that there are no lingering issues with task management.